### PR TITLE
Implement missing method, comment out non-existing method.

### DIFF
--- a/src/Entity/EntityCollection.php
+++ b/src/Entity/EntityCollection.php
@@ -3,6 +3,7 @@
 namespace Drupal\entity_collection\Entity;
 
 use Drupal\Core\Config\Entity\ConfigEntityBase;
+use Drupal\Core\Config\Entity\ConfigEntityInterface;
 use Drupal\entity_collection\Plugin\AdminUIInterface;
 use Drupal\entity_collection\Plugin\ListStyleInterface;
 use Drupal\entity_collection\Plugin\RowDisplayInterface;
@@ -216,6 +217,10 @@ class EntityCollection extends ConfigEntityBase implements EntityCollectionInter
    */
   public function getTree() {
     // TODO: Implement getTree() method.
+  }
+
+  public function getStorage() {
+    return $this->storage_settings;
   }
 
 }

--- a/src/Form/EntityCollectionForm.php
+++ b/src/Form/EntityCollectionForm.php
@@ -138,7 +138,7 @@ class EntityCollectionForm extends EntityForm {
       ),
     );
     if ( $entity_collection->isStorageConfigured() ) {
-      $form['storage_settings'] = $form['storage_settings'] + $entity_collection->getStorage()->getConfigForm($form, $form_state);
+      $form['storage_settings'] = $form['storage_settings'] + $entity_collection->getStorage()/*->getConfigForm($form, $form_state)*/;
     }
 
     /**


### PR DESCRIPTION
Temporary semi-fix, will be discarded to move this functionality to a service.
This is only needed to temporarily stop the fatal error.
